### PR TITLE
[SBL-235] 설문 응답, 당첨자 발생 Topic을 구독하고 알림을 보내는 Kafka Consumer 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yongalert/config/ObjectMapperConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/config/ObjectMapperConfig.kt
@@ -1,0 +1,13 @@
+package com.sbl.sulmun2yongalert.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ObjectMapperConfig {
+    @Bean
+    fun objectMapper(): ObjectMapper = ObjectMapper().registerModules(JavaTimeModule()).registerKotlinModule()
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/consumer/SurveyResponseNotificationConsumer.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/consumer/SurveyResponseNotificationConsumer.kt
@@ -1,0 +1,54 @@
+package com.sbl.sulmun2yongalert.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sbl.sulmun2yongalert.event.SurveyResponseEvent
+import com.sbl.sulmun2yongalert.service.NotificationService
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.DltHandler
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.annotation.RetryableTopic
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.retry.annotation.Backoff
+import org.springframework.stereotype.Component
+
+@Component
+class SurveyResponseNotificationConsumer(
+    private val notificationService: NotificationService,
+    private val objectMapper: ObjectMapper,
+) {
+    private val logger = LoggerFactory.getLogger(SurveyResponseNotificationConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["\${kafka.topics.survey-response}"],
+        groupId = "\${kafka.consumer-groups.survey-response}",
+    )
+    @RetryableTopic(
+        attempts = "5",
+        backoff = Backoff(delay = 5000, multiplier = 2.0),
+        autoCreateTopics = "true",
+        retryTopicSuffix = "-retry",
+        dltTopicSuffix = "-dlt",
+    )
+    fun listen(record: ConsumerRecord<String, String>) {
+        val message = record.value()
+        try {
+            val event = objectMapper.readValue(message, SurveyResponseEvent::class.java)
+            logger.info("Received event: ${event.participantId}")
+            notificationService.processNotification(event)
+        } catch (ex: Exception) {
+            logger.error("Error processing message: $message", ex)
+            throw ex
+        }
+    }
+
+    @DltHandler
+    fun handleDlt(
+        record: ConsumerRecord<String, String>,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) topic: String,
+    ) {
+        logger.error("Message sent to DLQ from topic $topic: ${record.value()}")
+        // DLQ로 들어간 메시지는 별도 모니터링 및 수동 처리 로직을 추가할 수 있음
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/consumer/WinningNotificationConsumer.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/consumer/WinningNotificationConsumer.kt
@@ -1,0 +1,55 @@
+package com.sbl.sulmun2yongalert.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sbl.sulmun2yongalert.event.WinningEvent
+import com.sbl.sulmun2yongalert.service.NotificationService
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.DltHandler
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.annotation.RetryableTopic
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.retry.annotation.Backoff
+import org.springframework.stereotype.Component
+
+@Component
+class WinningNotificationConsumer(
+    private val notificationService: NotificationService,
+    private val objectMapper: ObjectMapper,
+) {
+    private val logger = LoggerFactory.getLogger(SurveyResponseNotificationConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["\${kafka.topics.winning}"],
+        groupId = "\${kafka.consumer-groups.winning}",
+    )
+    @RetryableTopic(
+        attempts = "5",
+        backoff = Backoff(delay = 5000, multiplier = 2.0),
+        autoCreateTopics = "true",
+        retryTopicSuffix = "-retry",
+        dltTopicSuffix = "-dlt",
+    )
+    fun listen(record: ConsumerRecord<String, String>) {
+        val message = record.value()
+        try {
+            val event = objectMapper.readValue(message, WinningEvent::class.java)
+            logger.info("Received event: ${event.drawingHistoryId}")
+            notificationService.processNotification(event)
+        } catch (ex: Exception) {
+            logger.error("Error processing message: $message", ex)
+            // 예외를 재던져 @RetryableTopic이 재시도 로직을 수행하도록 함
+            throw ex
+        }
+    }
+
+    @DltHandler
+    fun handleDlt(
+        record: ConsumerRecord<String, String>,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) topic: String,
+    ) {
+        logger.error("Message sent to DLQ from topic $topic: ${record.value()}")
+        // DLQ로 들어간 메시지는 별도 모니터링 및 수동 처리 로직을 추가할 수 있음
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/entity/NotificationLogEntity.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/entity/NotificationLogEntity.kt
@@ -1,0 +1,33 @@
+package com.sbl.sulmun2yongalert.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "notification_log", uniqueConstraints = [UniqueConstraint(columnNames = ["eventId"])])
+data class NotificationLogEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @Column(nullable = false, unique = true)
+    val eventId: String,
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: NotificationStatus,
+    @Column(nullable = false)
+    var retryCount: Int = 0,
+    @Column(nullable = false)
+    val message: String,
+    @Column(nullable = false)
+    val targetUserId: UUID,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/entity/NotificationStatus.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/entity/NotificationStatus.kt
@@ -1,0 +1,7 @@
+package com.sbl.sulmun2yongalert.entity
+
+enum class NotificationStatus {
+    PENDING,
+    SUCCESS,
+    FAILED,
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/event/NotificationEvent.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/event/NotificationEvent.kt
@@ -1,0 +1,11 @@
+package com.sbl.sulmun2yongalert.event
+
+import java.util.UUID
+
+interface NotificationEvent {
+    fun getMessage(): String
+
+    fun getEventId(): String
+
+    fun getTargetUserId(): UUID
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/event/SurveyResponseEvent.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/event/SurveyResponseEvent.kt
@@ -1,0 +1,17 @@
+package com.sbl.sulmun2yongalert.event
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class SurveyResponseEvent(
+    val participantId: UUID,
+    val surveyId: UUID,
+    val surveyMakerId: UUID,
+    val timestamp: LocalDateTime,
+) : NotificationEvent {
+    override fun getMessage(): String = "설문 \"$surveyId\"에 참여자가 발생했습니다!\n참여 ID : $participantId\n참여 일시: $timestamp"
+
+    override fun getEventId(): String = "survey-response-$surveyMakerId"
+
+    override fun getTargetUserId(): UUID = surveyMakerId
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/event/WinningEvent.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/event/WinningEvent.kt
@@ -1,0 +1,19 @@
+package com.sbl.sulmun2yongalert.event
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class WinningEvent(
+    val drawingHistoryId: UUID,
+    val surveyId: UUID,
+    val surveyMakerId: UUID,
+    val rewardName: String,
+    val phoneNumber: String,
+    val timestamp: LocalDateTime,
+) : NotificationEvent {
+    override fun getMessage(): String = "설문 \"$surveyId\"에서 당첨자가 발생했습니다!\n당첨 상품 : $rewardName\n당첨자 연락처 : $phoneNumber\n당첨 일시 : $timestamp"
+
+    override fun getEventId(): String = "winning-$drawingHistoryId"
+
+    override fun getTargetUserId(): UUID = surveyMakerId
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/repository/NotificationLogRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/repository/NotificationLogRepository.kt
@@ -1,0 +1,8 @@
+package com.sbl.sulmun2yongalert.repository
+
+import com.sbl.sulmun2yongalert.entity.NotificationLogEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NotificationLogRepository : JpaRepository<NotificationLogEntity, Long>

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/service/NotificationSender.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/service/NotificationSender.kt
@@ -1,0 +1,7 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.event.NotificationEvent
+
+interface NotificationSender {
+    fun sendNotification(event: NotificationEvent)
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/service/NotificationService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/service/NotificationService.kt
@@ -1,0 +1,57 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.entity.NotificationLogEntity
+import com.sbl.sulmun2yongalert.entity.NotificationStatus
+import com.sbl.sulmun2yongalert.event.NotificationEvent
+import com.sbl.sulmun2yongalert.repository.NotificationLogRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class NotificationService(
+    private val notificationLogRepository: NotificationLogRepository,
+    private val notificationSender: NotificationSender,
+) {
+    private val logger = LoggerFactory.getLogger(NotificationService::class.java)
+
+    @Transactional
+    fun processNotification(event: NotificationEvent) {
+        // DB에 알림 로그를 저장하면서 중복 체크 (eventId unique)
+        val notificationLog =
+            NotificationLogEntity(
+                eventId = event.getEventId(),
+                status = NotificationStatus.PENDING,
+                message = event.getMessage(),
+                targetUserId = event.getTargetUserId(),
+            )
+        try {
+            notificationLogRepository.save(notificationLog)
+        } catch (e: DataIntegrityViolationException) {
+            // 이미 처리된 이벤트면 재전송 스킵
+            logger.info("중복 이벤트 : ${event.getEventId()}")
+            return
+        }
+
+        try {
+            // 알림 전송
+            notificationSender.sendNotification(event)
+            // 전송 성공 시 상태 업데이트
+            notificationLog.status = NotificationStatus.SUCCESS
+            logger.info("알림 전송 성공 : ${event.getEventId()}")
+        } catch (ex: Exception) {
+            // 전송 실패 시 상태를 FAILED로 설정해 재시도 대상에 포함
+            notificationLog.status = NotificationStatus.FAILED
+            logger.error(
+                "알림 전송 실패 : ${event.getEventId()}\n재시도 횟수 : ${notificationLog.retryCount}\n",
+                ex,
+            )
+        } finally {
+            notificationLog.retryCount += 1
+            notificationLog.updatedAt = LocalDateTime.now()
+            notificationLogRepository.save(notificationLog)
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yongalert/service/SlackNotificationSender.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yongalert/service/SlackNotificationSender.kt
@@ -1,0 +1,33 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.event.NotificationEvent
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class SlackNotificationSender(
+    @Value("\${slack.webhook.url}") private val slackWebhookUrl: String,
+) : NotificationSender {
+    private val logger = LoggerFactory.getLogger(SlackNotificationSender::class.java)
+    private val restTemplate = RestTemplate()
+
+    override fun sendNotification(event: NotificationEvent) {
+        val payload = mapOf("text" to event.getMessage())
+
+        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
+        val request: HttpEntity<Map<String, String>> = HttpEntity(payload, headers)
+
+        try {
+            restTemplate.postForEntity(slackWebhookUrl, request, String::class.java)
+            logger.info("Slack 알림 전송 성공 : ${event.getEventId()}")
+        } catch (ex: Exception) {
+            logger.error("Slack 알림 전송 실패 : ${event.getEventId()}", ex)
+            throw ex
+        }
+    }
+}

--- a/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceFailureTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceFailureTest.kt
@@ -1,0 +1,62 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.entity.NotificationLogEntity
+import com.sbl.sulmun2yongalert.entity.NotificationStatus
+import com.sbl.sulmun2yongalert.event.SurveyResponseEvent
+import com.sbl.sulmun2yongalert.repository.NotificationLogRepository
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ExtendWith(MockKExtension::class)
+class NotificationServiceFailureTest {
+    @MockK
+    lateinit var notificationLogRepository: NotificationLogRepository
+
+    @MockK
+    lateinit var notificationSender: NotificationSender
+
+    @InjectMockKs
+    lateinit var notificationService: NotificationService
+
+    private val testEvent =
+        SurveyResponseEvent(
+            participantId = UUID.randomUUID(),
+            surveyId = UUID.randomUUID(),
+            surveyMakerId = UUID.randomUUID(),
+            timestamp = LocalDateTime.now(),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        every { notificationLogRepository.save(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `알림 전송이 실패하면 상태가 FAILED로 업데이트되어야 한다`() {
+        // Arrange: notificationSender.sendNotification이 예외를 던지도록 설정
+        every { notificationSender.sendNotification(testEvent) } throws RuntimeException("Simulated failure")
+
+        // Act
+        notificationService.processNotification(testEvent)
+
+        // Assert: repository.save()가 두 번 호출됨 (초기 저장 + 업데이트)
+        val capturedEntities = mutableListOf<NotificationLogEntity>()
+        verify(exactly = 2) { notificationLogRepository.save(capture(capturedEntities)) }
+        val finalLog = capturedEntities.last()
+        assertNotNull(finalLog)
+        assertEquals(testEvent.getEventId(), finalLog.eventId)
+        assertEquals(NotificationStatus.FAILED, finalLog.status)
+    }
+}

--- a/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceRetryTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceRetryTest.kt
@@ -1,0 +1,71 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.event.NotificationEvent
+import com.sbl.sulmun2yongalert.repository.NotificationLogRepository
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.dao.DataIntegrityViolationException
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class NotificationServiceRetryTest {
+    @MockK
+    lateinit var notificationLogRepository: NotificationLogRepository
+
+    @MockK
+    lateinit var notificationSender: NotificationSender
+
+    @InjectMockKs
+    lateinit var notificationService: NotificationService
+
+    private val testEvent = mockk<NotificationEvent>()
+    private val eventId = UUID.randomUUID().toString()
+    private val message = "text message"
+    private val targetUserId = UUID.randomUUID()
+
+    // 호출 횟수를 구분하기 위한 변수 (첫 번째 processNotification()에서는 정상, 두 번째 호출에서는 중복 발생)
+    private var saveCallCount = 0
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        saveCallCount = 0
+        every { testEvent.getEventId() } answers { eventId }
+        every { testEvent.getMessage() } answers { message }
+        every { testEvent.getTargetUserId() } answers { targetUserId }
+        // processNotification 내부에서 동일 eventId에 대해 repository.save()가 두 번 호출됩니다.
+        // 첫 번째 호출에서는 정상 반환, 두 번째 호출(재시도 시도 중 신규 로그 삽입)에서는 중복으로 간주하여 예외 발생
+        every { notificationLogRepository.save(match { it.eventId == testEvent.getEventId() }) } answers {
+            saveCallCount++
+            if (saveCallCount <= 2) {
+                firstArg()
+            } else {
+                throw DataIntegrityViolationException(
+                    "Duplicate event",
+                    RuntimeException("Simulated duplicate"),
+                )
+            }
+        }
+        // 첫 번째 호출에서 notificationSender.sendNotification()가 예외를 던지도록 설정
+        every { notificationSender.sendNotification(testEvent) } throws RuntimeException("Simulated failure")
+    }
+
+    @Test
+    fun `재시도 시 이미 처리된 이벤트이면 알림 전송을 스킵해야 한다`() {
+        // 첫 번째 호출: 알림 전송 시도 -> 예외 발생하지만 내부에서 catch하여 FAILED 상태로 업데이트됨.
+        notificationService.processNotification(testEvent)
+        // 두 번째 호출(재시도): DB 저장 시 unique 제약에 의해 예외가 발생하여 바로 return됨.
+        notificationService.processNotification(testEvent)
+
+        // verify: notificationSender.sendNotification()은 첫 번째 호출에서 한 번만 호출되어야 함.
+        verify(exactly = 1) { notificationSender.sendNotification(testEvent) }
+    }
+}

--- a/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceSuccessTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yongalert/service/NotificationServiceSuccessTest.kt
@@ -1,0 +1,61 @@
+package com.sbl.sulmun2yongalert.service
+
+import com.sbl.sulmun2yongalert.entity.NotificationLogEntity
+import com.sbl.sulmun2yongalert.entity.NotificationStatus
+import com.sbl.sulmun2yongalert.event.NotificationEvent
+import com.sbl.sulmun2yongalert.repository.NotificationLogRepository
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ExtendWith(MockKExtension::class)
+class NotificationServiceSuccessTest {
+    @MockK
+    lateinit var notificationLogRepository: NotificationLogRepository
+
+    @MockK
+    lateinit var notificationSender: NotificationSender
+
+    @InjectMockKs
+    lateinit var notificationService: NotificationService
+
+    private val testEvent = mockk<NotificationEvent>()
+    private val eventId = UUID.randomUUID().toString()
+    private val message = "text message"
+    private val targetUserId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        every { testEvent.getEventId() } answers { eventId }
+        every { testEvent.getMessage() } answers { message }
+        every { testEvent.getTargetUserId() } answers { targetUserId }
+        every { notificationLogRepository.save(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `알림 전송이 성공하면 상태가 SUCCESS로 업데이트되어야 한다`() {
+        // Arrange: 정상 전송 가정
+        every { notificationSender.sendNotification(testEvent) } returns Unit
+
+        // Act
+        notificationService.processNotification(testEvent)
+
+        val capturedEntities = mutableListOf<NotificationLogEntity>()
+        verify(exactly = 2) { notificationLogRepository.save(capture(capturedEntities)) }
+        val finalLog = capturedEntities.last()
+        assertNotNull(finalLog)
+        assertEquals(eventId, finalLog.eventId)
+        assertEquals(NotificationStatus.SUCCESS, finalLog.status)
+    }
+}


### PR DESCRIPTION
## 📢 설명
- 설문 서버에서 설문 응답 Topic과 당첨자 발생 Topic에 발행하는 이벤트를 Consume하는 Kafka Consumer 구현
- 구독한 이벤트를 Kafka에서 가져와서 알림을 전송하는 기능 구현
- 알림 유실을 방지하기 위해
  - 알림 Log를 DB에 저장
  - 알림 전송 과정에서 RetryableException(일시적인 네트워크 오류 등) 발생 시 @RetryableTopic 어노테이션을 통해 지수 백오프 방식 재시도 구현
  - 5회 실패 시 DLT에 삽입하여 예외 상황을 확인할 수 있도록 구현
- 알림 중복 전송을 최소화하기 위해 알림 Log 테이블에 저장하는 Idempotency Key(멱등키)에 DB Unique Key 제약조건을 추가, 알림 전송 상태를 관리